### PR TITLE
Indent lines after one ending with ':'

### DIFF
--- a/indent/groovy.vim
+++ b/indent/groovy.vim
@@ -131,7 +131,7 @@ function GetGroovyIndent()
     endif
 
     " If last line end with (
-    if getline(lnum) =~ '[\(]\s*$'
+    if getline(lnum) =~ '[\(:]\s*$'
       let theIndent = indent(lnum) + &sw
     endif
   endif


### PR DESCRIPTION
This will indent the cases inside a `switch` statement:

``` groovy
switch (num) {
    case 1:
        println "One"
        break
    case 2:
        println "Two"
        break
    case 3:
        println "Three"
        break
    default:
        println "Something else"
}
```
