### PR TITLE
make sure regex doesn't match against "if"/"else"

### DIFF
--- a/indent/groovy.vim
+++ b/indent/groovy.vim
@@ -126,7 +126,7 @@ function GetGroovyIndent()
   " Fixed several indent problems
   if theIndent > indent(lnum)
     " If no '{ -> ( if else' , then same indent as previous line
-    if getline(lnum) !~ '[\{>\(]\s*$' && getline(lnum) !~ '\s*\(if\|else\)\s*'
+    if getline(lnum) !~ '[\{>\(]\s*$' && getline(lnum) !~ '\v^\s*(if|else)\>'
       let theIndent = indent(lnum)
     endif
 


### PR DESCRIPTION
I noticed that lines following a line that contain "if"/"else" as a substring of a symbol are more indented than they should be after re-indenting the code using `=`. Looking at the plugin it looks like the regex can be adjusted to make the regex more specific and exclude internal matches. 